### PR TITLE
Bug/issue#57

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ from photosynthesis_metrics import TVLoss
 
 loss = TVLoss()
 prediction = torch.rand(3, 3, 256, 256, requires_grad=True)
-target = torch.rand(3, 3, 256, 256)
-ouput: torch.Tensor = loss(prediction, target, data_range=1.)
+output: torch.Tensor = loss(prediction)
 output.backward()
 ```
 </p>

--- a/photosynthesis_metrics/tv.py
+++ b/photosynthesis_metrics/tv.py
@@ -23,7 +23,7 @@ def _adjust_tensor_dimensions(x: torch.Tensor):
 def _validate_input(x: torch.Tensor) -> None:
     """Validates input tensor"""
     assert isinstance(x, torch.Tensor), f'Input must be a torch.Tensor, got {type(x)}.'
-    assert len(x.shape) == 4, f'Input image must be 4D tensor, got image of shape {x.shape}.'
+    assert x.dim() == 4, f'Input image must be 4D tensor, got image of shape {x.shape}.'
 
 
 def total_variation(x: torch.Tensor, size_average: bool = True, reduction_type: str = 'l2') -> torch.Tensor:

--- a/photosynthesis_metrics/tv.py
+++ b/photosynthesis_metrics/tv.py
@@ -5,7 +5,25 @@ r"""Implemetation of Total Variation metric, based on article
 import torch
 from torch.nn.modules.loss import _Loss
 
-from photosynthesis_metrics.utils import _adjust_dimensions, _validate_input
+
+def _adjust_tensor_dimensions(x: torch.Tensor):
+    r"""Expands input tensor dimensions to 4D
+        """
+    num_dimensions = x.dim()
+    if num_dimensions == 2:
+        x = x.expand(1, 1, *x.shape)
+    elif num_dimensions == 3:
+        x = x.expand(1, *x.shape)
+    elif num_dimensions != 4:
+        raise ValueError('Expected 2, 3, or 4 dimensions (got {})'.format(num_dimensions))
+
+    return x
+
+
+def _validate_input(x: torch.Tensor) -> None:
+    """Validates input tensor"""
+    assert isinstance(x, torch.Tensor), f'Input must be a torch.Tensor, got {type(x)}.'
+    assert len(x.shape) == 4, f'Input image must be 4D tensor, got image of shape {x.shape}.'
 
 
 def total_variation(x: torch.Tensor, size_average: bool = True, reduction_type: str = 'l2') -> torch.Tensor:

--- a/photosynthesis_metrics/tv.py
+++ b/photosynthesis_metrics/tv.py
@@ -118,8 +118,8 @@ class TVLoss(_Loss):
         Returns:
             Value of TV loss to be minimized.
         """
-        prediction = _adjust_tensor_dimensions(prediction)
         _validate_input(prediction)
+        prediction = _adjust_tensor_dimensions(prediction)
 
         return self.compute_metric(prediction)
 

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -19,31 +19,24 @@ def test_tv_works(prediction: torch.Tensor) -> None:
     measure = total_variation(prediction, size_average=True, reduction_type='l2')
     assert measure > 0
     measure = total_variation(prediction, size_average=True, reduction_type='l1')
+    assert measure > 0
     measure = total_variation(prediction, size_average=True, reduction_type='l2_squared')
+    assert measure > 0
 
 
-def test_tvloss_init(prediction: torch.Tensor, target: torch.Tensor) -> None:
+def test_tvloss_init() -> None:
     TVLoss()
 
 
-def test_tvloss(prediction: torch.Tensor, target: torch.Tensor) -> None:
+def test_tvloss(prediction: torch.Tensor) -> None:
     loss = TVLoss()
-    res = loss(prediction, target)
+    res = loss(prediction)
     assert res > 0
-
-
-def test_tv_zero_for_equal_tensors(prediction: torch.Tensor):
-    loss = TVLoss()
-    target = prediction.clone()
-    measure = loss(prediction, target)
-    assert measure <= 1e-6, f'TV for equal tensors must be 0, got {measure}'
 
 
 def test_tv_for_known_answer():
     # Tensor with `l1` TV = (10 - 1) * 2  * 2 = 36
     prediction = torch.eye(10).reshape((1, 1, 10, 10))
-    # Tensor with TV = 0
-    target = torch.zeros((1, 1, 10, 10))
     loss = TVLoss(reduction_type='l1')
-    measure = loss(prediction, target)
+    measure = loss(prediction)
     assert measure == 36., f'TV for this tensors must be 36., got {measure}'


### PR DESCRIPTION
I changed the TVLoss computation to be based on only predicted image, as it's [used](https://arxiv.org/abs/1603.08155) as a regularizer applied to the predicted images during NN training.

As the functions `_adjust_dimensions` and `_validate_inputs` from `utils` module only support two input tensors, I added their counterparts `_adjust_tensor_dimensions` and `_validate_input` directly in `tv` module. In the future, they may be combined with the corresponding functions from utils.

The README file and tests are changed to be up to the fix.